### PR TITLE
Updates for python3 compatibility, column labelling and output filename improvements

### DIFF
--- a/lesson-2/code/Sense-Logger.py
+++ b/lesson-2/code/Sense-Logger.py
@@ -27,9 +27,9 @@ def file_setup(filename):
         header.append("pressure")
     if ORIENTATION:
         header.extend(["pitch","roll","yaw"])
-    if ACCELERATION:
-        header.extend(["mag_x","mag_y","mag_z"])
     if MAG:
+        header.extend(["mag_x","mag_y","mag_z"])
+    if ACCELERATION:
         header.extend(["accel_x","accel_y","accel_z"])
     if GYRO:
         header.extend(["gyro_x","gyro_y","gyro_z"])
@@ -59,19 +59,19 @@ def get_sense_data():
         sense_data.append(sense.get_pressure())
         
     if ORIENTATION:
-        yaw,pitch,roll = sense.get_orientation().values()        
+        yaw,pitch,roll = [sense.get_orientation()[key] for key in ['yaw','pitch','roll']]
         sense_data.extend([pitch,roll,yaw])
 
     if MAG:
-        mag_x,mag_y,mag_z = sense.get_compass_raw().values()
+        mag_x,mag_y,mag_z = [sense.get_compass_raw()[key] for key in ['x','y','z']]
         sense_data.append([mag_x,mag_y,mag_z])
 
     if ACCELERATION:
-        x,y,z = sense.get_accelerometer_raw().values()
+        x,y,z = [sense.get_accelerometer_raw()[key] for key in ['x','y','z']]
         sense_data.extend([x,y,z])
 
     if GYRO:
-        gyro_x,gyro_y,gyro_z = sense.get_gyroscope_raw().values()
+        gyro_x,gyro_y,gyro_z = [sense.get_gyroscope_raw()[key] for key in ['x','y','z']]
         sense_data.extend([gyro_x,gyro_y,gyro_z])
     
     sense_data.append(datetime.now())
@@ -116,9 +116,9 @@ dev = get_joystick()
 batch_data= []
 
 if BASENAME == "":
-    filename = "SenseLog-"+str(datetime.now())+".csv"
+    filename = "SenseLog-"+str(datetime.now().strftime("%Y-%m-%d-%H%M"))+".csv"
 else:
-    filename = BASENAME+"-"+str(datetime.now())+".csv"
+    filename = BASENAME+"-"+str(datetime.now().strftime("%Y-%m-%d-%H%M"))+".csv"
 
 file_setup(filename)
 


### PR DESCRIPTION
1) Column headers for accelerometer and magnetometer were muddled - I've just swapped them.

2) In Python3 when you use (say)  get_accelerometer_raw().values() you are getting the key values of the dictionary get_accelerometer_raw(). Although these are ordered in python2.x, they are not in Python3 so you will get inconsistent results. New code will correctly get the values into the correctly named variables for the get.accelerometer_raw, get.gyroscope_raw, get.compass_raw  and get.orientation functions.

3) Added some nicer formatting to datetime used in logging filenames. Having spaces and colons in filenames can be problematic, especially if trying to use scp to copy off . 
